### PR TITLE
style(Charts): impose max width on tooltip + update display

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
             {
               "type": "refactor",
               "release": "minor"
+            },
+            {
+              "type": "style",
+              "release": "patch"
             }
           ]
         }

--- a/src/constants/chartConstants.ts
+++ b/src/constants/chartConstants.ts
@@ -69,16 +69,18 @@ export const TOOLTIP_OTHER_PROPS: {
 } = {
   wrapperStyle: {
     zIndex: 10,
+    maxWidth: '240px',
   },
   allowEscapeViewBox: { x: true, y: true },
 };
 
 export const TOOLTIP_STYLE: CSS.Properties = {
   backgroundColor: 'rgba(255, 255, 255, 0.9)',
+  backdropFilter: 'blur(4px)',
   padding: '5px',
-  border: '1px solid grey',
-  boxShadow: '0px 0px 2px rgba(0, 0, 0, 0.9)',
-  borderRadius: '2px',
+  border: '1px solid #DDD',
+  boxShadow: '0px 0px 4px rgba(0, 0, 0, 0.1)',
+  borderRadius: '4px',
   textAlign: 'left',
 };
 
@@ -91,7 +93,7 @@ export const LABEL_STYLE: CSS.Properties = {
 
 export const COUNT_STYLE: CSS.Properties = {
   fontWeight: 'normal',
-  fontSize: '11px',
+  fontSize: '12px',
   padding: '0',
   margin: '0',
 };

--- a/test/js/TestPieChart.tsx
+++ b/test/js/TestPieChart.tsx
@@ -3,7 +3,11 @@ import { PieChart } from '../../src/index';
 
 const TestPieChart = () => (
   <PieChart
-    data={[{x: "AB", y: 50}, {x: "NB", y: 75}, {x: "SB", y: 60}]}
+    data={[
+      { x: 'AB this is a very very very very very very very very very very long label', y: 50 },
+      { x: 'NB', y: 75 },
+      { x: 'SB', y: 60 },
+    ]}
     onClick={(f) => {
       console.log(f);
       alert(JSON.stringify(f, null, 2));


### PR DESCRIPTION
test with `npm test` + hovering over bar/pie sections in the test app.

adds a max width for long tooltips to make their rendering more predictable in our front ends + makes the border/shadow styling a bit less aggressive.