### PR TITLE
fix: ChartConfigProvider allow multiple elements as children

### DIFF
--- a/src/ChartConfigProvider.tsx
+++ b/src/ChartConfigProvider.tsx
@@ -1,4 +1,5 @@
-import React, { type ReactNode, useContext } from 'react';
+import React, { useContext } from 'react';
+import type { ReactNode } from 'react';
 
 import { DEFAULT_CHART_THEME, defaultTranslationObject } from './constants/chartConstants';
 import type { ChartTheme, LngDictionary, SupportedLng, TranslationObject } from './types/chartTypes';

--- a/src/ChartConfigProvider.tsx
+++ b/src/ChartConfigProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { type ReactNode, useContext } from 'react';
 
 import { DEFAULT_CHART_THEME, defaultTranslationObject } from './constants/chartConstants';
 import type { ChartTheme, LngDictionary, SupportedLng, TranslationObject } from './types/chartTypes';
@@ -63,7 +63,7 @@ type ChartConfigProviderProps = {
   theme?: ChartTheme;
   Lng: string;
   translationMap?: TranslationObject;
-  children: React.ReactElement;
+  children: ReactNode;
   globalThreshold?: number;
   maxLabelChars?: number;
 };


### PR DESCRIPTION
Before this change, only one child element was permitted inside ChartConfigProvider. We want to allow multiple sibling elements too.