### PR TITLE
fix(bar): consistent vertical or horizontal alignment of bar labels

### DIFF
--- a/src/Components/Charts/BaseBarChart.tsx
+++ b/src/Components/Charts/BaseBarChart.tsx
@@ -6,7 +6,6 @@ import {
   CartesianGrid,
   Cell,
   Label,
-  type LabelProps,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -24,7 +23,13 @@ import {
   COUNT_KEY,
 } from '../../constants/chartConstants';
 
-import { BarCountFillMode, BaseBarChartProps, CategoricalChartDataItem, TooltipPayload } from '../../types/chartTypes';
+import {
+  BarCountFillMode,
+  BaseBarChartProps,
+  CategoricalChartDataItem,
+  CustomBarLabelProps,
+  TooltipPayload,
+} from '../../types/chartTypes';
 import { useChartTranslation } from '../../ChartConfigProvider';
 import NoData from '../NoData';
 import { useTransformedChartData } from '../../util/chartUtils';
@@ -89,6 +94,9 @@ const BaseBarChart = ({
     return <NoData height={height} />;
   }
 
+  // string length of widest label
+  const valuesMaxStringLength = Math.max(...data.map((d) => (d.y ?? 0).toString().length));
+
   // Regarding XAxis.ticks below:
   //  The weird conditional is added from https://github.com/recharts/recharts/issues/2593#issuecomment-1311678397
   //  Basically, if data is empty, Recharts will default to a domain of [0, "auto"] and our tickFormatter trips up
@@ -124,7 +132,7 @@ const BaseBarChart = ({
               onClick={onClick}
               onMouseEnter={onHover}
               maxBarSize={70}
-              label={showBarCounts ? BarLabel : undefined}
+              label={showBarCounts ? <BarLabel valuesMaxStringLength={valuesMaxStringLength} /> : undefined}
             >
               {data.map((entry, index) => (
                 <Cell key={entry.x} fill={fill(entry, index)} />
@@ -169,7 +177,7 @@ const BarLabelContext = createContext<{ barCountFillMode: BarCountFillMode }>({ 
 /**
  * Component for rendering bar counts directly above bars in the plot.
  */
-const BarLabel = ({ x, y, width, value, fill }: LabelProps) => {
+const BarLabel = ({ x, y, width, value, fill, valuesMaxStringLength }: CustomBarLabelProps) => {
   const { barCountFillMode } = useContext(BarLabelContext);
 
   // Funky conversion to placate TypeScript. In reality, width should always be a number here, the Recharts types are
@@ -177,9 +185,9 @@ const BarLabel = ({ x, y, width, value, fill }: LabelProps) => {
   // noinspection SuspiciousTypeOfGuard
   const finalWidth = typeof width === 'string' ? MIN_BAR_WIDTH_FOR_COUNTS : (width ?? 0);
 
-  // Flip the labels to vertical text when the bar width is (roughly) less than the text width
+  // Flip the labels to vertical text when the bar width is (roughly) less than the width of widest count
   // noinspection SuspiciousTypeOfGuard
-  const vertical = finalWidth < (value ?? '').toString().length * BAR_LABEL_APPROX_NUMBER_WIDTH;
+  const vertical = finalWidth < valuesMaxStringLength * BAR_LABEL_APPROX_NUMBER_WIDTH;
   // noinspection SuspiciousTypeOfGuard
   const xPos = typeof x === 'number' ? x + finalWidth / 2 : x;
 

--- a/src/types/chartTypes.ts
+++ b/src/types/chartTypes.ts
@@ -1,4 +1,4 @@
-import type { PieProps, BarProps } from 'recharts';
+import type { PieProps, BarProps, LabelProps } from 'recharts';
 import type { CartesianChartProps } from 'recharts/types/util/types';
 import { COUNT_KEY, OTHER_KEY } from '../constants/chartConstants';
 
@@ -97,4 +97,8 @@ export interface BarChartProps extends Omit<BaseBarChartProps, 'chartFill' | 'ot
 }
 export interface HistogramProps extends Omit<BaseBarChartProps, 'chartFill' | 'otherFill'> {
   colorTheme?: keyof ChartTheme['bar'];
+}
+
+export interface CustomBarLabelProps extends LabelProps {
+  valuesMaxStringLength: number;
 }

--- a/test/js/TestBarChart.tsx
+++ b/test/js/TestBarChart.tsx
@@ -18,7 +18,7 @@ const TestBarChart = () => {
           <BarChart
             data={[
               { id: '0', x: 'AB', y: 50 },
-              { id: '1', x: 'NB', y: 75 },
+              { id: '1', x: 'NB', y: 101 },
               { id: '2', x: 'SB', y: 60 },
               { id: '3', x: 'AU', y: 30 },
               { id: '4', x: 'XA', y: 80 },
@@ -49,7 +49,7 @@ const TestBarChart = () => {
           <BarChart
             data={[
               { id: '0', x: 'AB', y: 50 },
-              { id: '1', x: 'NB', y: 75 },
+              { id: '1', x: 'NB', y: 101 },
               { id: '2', x: 'SB', y: 60 },
               { id: '3', x: 'AU', y: 30 },
               {


### PR DESCRIPTION
Make bar labels consistently either all vertical or all horizontal (Redmine 2788).

Minimal fix here is to decide vertical or not based on the biggest label. 

In practice we call toString().length on each value and pick the max. The obvious optimization of finding numeric max first and calling toString() only once has roughly the same performance, even with thousands of entries. In both cases we are only approximating the real value we care about (pixel width of the label).


