### PR TITLE
feat: enable npm provenance via trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,4 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         }
       ],
       "@semantic-release/release-notes-generator",
-      "@semantic-release/npm",
+      ["@semantic-release/npm", { "provenance": true }],
       "@semantic-release/github",
       "@semantic-release/git"
     ]


### PR DESCRIPTION
## Summary

- Add `id-token: write` permission to release workflow for OIDC token generation
- Enable `provenance: true` in `@semantic-release/npm` plugin config