### PR TITLE
fix: restore env vars needed by semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,4 +27,5 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,4 +25,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
## Summary

- Restore `GITHUB_TOKEN` env var — required by semantic-release to push git tags and create GitHub releases
- Restore `NPM_TOKEN` env var — required by `@semantic-release/npm` to publish to registry